### PR TITLE
Switch to chokidar

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,14 @@ watcher.remove('./somefolder/dontcare.*');
 // stop watching entirely
 watcher.close();
 
-// options can be passed to the underlying watch lib as the second arg
+// options can be passed to the underlying watch lib (chokidar) as a second arg
 watcher = watch('./*.js', {usePolling: true});
 ```
+
+[Chokidar options reference](https://github.com/paulmillr/chokidar#api)
+
+*Note:* glob-watcher overrides chokidar's default `ignoreInitial` setting to
+`true` if you do not set it explicitly. 
 
 
 [npm-url]: https://npmjs.org/package/glob-watcher

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ watcher.on('change', function(evt) {
 
 // add files after it has been created
 watcher.add('./somefolder/somefile.js');
+
+// stop watching certain files
+watcher.remove('./somefolder/dontcare.*');
+
+// stop watching entirely
+watcher.close();
+
+// options can be passed to the underlying watch lib as the second arg
+watcher = watch('./*.js', {usePolling: true});
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -2,15 +2,10 @@ var chokidar = require('chokidar');
 var anymatch = require('anymatch');
 var EventEmitter = require('events').EventEmitter;
 
-function mapEvents(evt) {
-  switch (evt) {
-    case 'add':
-      return 'added';
-    case 'unlink':
-      return 'deleted';
-    case 'change':
-      return 'changed';
-  }
+var eventMap = {
+  add: 'added',
+  unlink: 'deleted',
+  change: 'changed'
 }
 
 module.exports = function(glob, opts, cb) {
@@ -33,7 +28,8 @@ module.exports = function(glob, opts, cb) {
   var filteredCbs = [];
 
   watcher.on('all', function(evt, path, stats){
-    evt = mapEvents(evt);
+    // convert from chokidar event names to glob-watcher's original names
+    evt = eventMap[evt];
     if (!evt) {
       return;
     }

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = function(glob, opts, cb) {
 
   opts = opts || {};
 
+  // overriding chokidar's default if user did not set it explicitly
   if (opts.ignoreInitial == null) {
     opts.ignoreInitial = true;
   }

--- a/index.js
+++ b/index.js
@@ -1,15 +1,15 @@
-var gaze = require('gaze');
+var chokidar = require('chokidar');
+var anymatch = require('anymatch');
 var EventEmitter = require('events').EventEmitter;
 
-function onWatch(out, cb){
-  return function(err, rwatcher){
-    if (err) out.emit('error', err);
-    rwatcher.on('all', function(evt, path, old){
-      var outEvt = {type: evt, path: path};
-      if(old) outEvt.old = old;
-      out.emit('change', outEvt);
-      if(cb) cb();
-    });
+function mapEvents(evt) {
+  switch (evt) {
+    case 'add':
+      return 'added';
+    case 'unlink':
+      return 'deleted';
+    case 'change':
+      return 'changed';
   }
 }
 
@@ -21,22 +21,62 @@ module.exports = function(glob, opts, cb) {
     opts = {};
   }
 
-  var watcher = gaze(glob, opts, onWatch(out, cb));
+  opts = opts || {};
 
-  watcher.on('end', out.emit.bind(out, 'end'));
+  if (opts.ignoreInitial == null) {
+    opts.ignoreInitial = true;
+  }
+
+  var watcher = chokidar.watch(glob, opts);
+
+  var nomatch = true;
+  var filteredCbs = [];
+
+  watcher.on('all', function(evt, path, stats){
+    evt = mapEvents(evt);
+    if (!evt) {
+      return;
+    }
+    nomatch = false;
+    var outEvt = {
+      type: evt,
+      path: path
+    };
+    if (stats) {
+      outEvt.stats = stats;
+    }
+    out.emit('change', outEvt);
+    filteredCbs.forEach(function(pair) {
+      if (pair.filter(path)) {
+        pair.cb();
+      }
+    });
+    cb && cb();
+  });
+  watcher.on('ready', function() {
+    if (nomatch) {
+      out.emit('nomatch');
+    }
+    out.emit('ready');
+  });
   watcher.on('error', out.emit.bind(out, 'error'));
-  watcher.on('ready', out.emit.bind(out, 'ready'));
-  watcher.on('nomatch', out.emit.bind(out, 'nomatch'));
 
-  out.end = function(){
-    return watcher.close();
-  };
   out.add = function(glob, cb){
-    return watcher.add(glob, onWatch(out, cb));
+    if (cb) {
+      filteredCbs.push({
+        filter: anymatch(glob),
+        cb: cb
+      });
+    }
+    watcher.add(glob);
+    return watcher;
   };
-  out.remove = function(glob){
-    return watcher.remove(glob);
-  };
+  out.end = function() {
+    watcher.close();
+    out.emit('end');
+    return watcher;
+  }
+  out.remove = watcher.unwatch.bind(watcher);
   out._watcher = watcher;
 
   return out;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lib"
   ],
   "dependencies": {
-    "gaze": "^0.5.1"
+    "anymatch": "^1.2.1",
+    "chokidar": "^1.0.0"
   },
   "devDependencies": {
     "mocha": "^2.0.1",


### PR DESCRIPTION
* io.js compatibility (update/correction: gaze 0.5.1 *is* compatible with io.js also, but 0.6.* isn't)
* not as buggy

This is aimed at establishing parity with prior behavior using gaze, except for swapping out `old` for `stats` as the extra argument coming from the watcher's events.

Switching to chokidar's regular event names (sooner or later) would be fine too if it wouldn't be too disruptive for downstream users of this module to adjust.

Please evaluate and let me know if there's any issue or concern. If not, I can release chokidar 1.0.0 before you push this out.