### PR TITLE
add `events` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ Default: `true`
 
 ##### `options.events`
 
-An array of event names to listen for. Useful if you only need to watch specific events.
+An event name or array of event names to listen for. Useful if you only need to watch specific events.
 
-Type: `Array`
+Type: `String | Array<String>`
 
 Default: `[ 'add', 'change', 'unlink' ]`
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ Type: `Boolean`
 
 Default: `true`
 
+##### `options.events`
+
+An array of event names to listen for. Useful if you only need to watch specific events.
+
+Type: `Array`
+
+Default: `[ 'add', 'change', 'unlink' ]`
+
 ##### other
 
 Options are passed directly to [lodash.debounce][lodash-debounce] and [chokidar][chokidar], so all their options are supported. Any debounce-related options are documented in [lodash.debounce][lodash-debounce]. Any chokidar-related options are documented in [chokidar][chokidar].

--- a/index.js
+++ b/index.js
@@ -56,10 +56,16 @@ function watch(glob, options, cb) {
 
   if (typeof cb === 'function') {
     var fn = debounce(onChange, opt.delay, opt);
-    watcher
-      .on('change', fn)
-      .on('unlink', fn)
-      .on('add', fn);
+
+    if (!opt.events) {
+      opt.events = ['add', 'change', 'unlink'];
+    }
+
+    opt.events.forEach(
+      function(eventName) {
+        watcher.on(eventName, fn);
+      }
+    );
   }
 
   return watcher;

--- a/index.js
+++ b/index.js
@@ -10,8 +10,9 @@ function assignNullish(objValue, srcValue) {
 }
 
 var defaults = {
-  ignoreInitial: true,
   delay: 200,
+  events: ['add', 'change', 'unlink'],
+  ignoreInitial: true,
   queue: true,
 };
 
@@ -23,11 +24,7 @@ function watch(glob, options, cb) {
 
   var opt = assignWith({}, defaults, options, assignNullish);
 
-  if (!opt.events) {
-    opt.events = ['add', 'change', 'unlink'];
-  }
-
-  if (!(opt.events instanceof Array)) {
+  if (!Array.isArray(opt.events)) {
     opt.events = [opt.events];
   }
 
@@ -65,9 +62,11 @@ function watch(glob, options, cb) {
   if (typeof cb === 'function') {
     var fn = debounce(onChange, opt.delay, opt);
 
-    opt.events.forEach(function watchEvent(eventName) {
+    function watchEvent(eventName) {
       watcher.on(eventName, fn);
-    });
+    }
+
+    opt.events.forEach(watchEvent);
   }
 
   return watcher;

--- a/index.js
+++ b/index.js
@@ -65,11 +65,9 @@ function watch(glob, options, cb) {
   if (typeof cb === 'function') {
     var fn = debounce(onChange, opt.delay, opt);
 
-    function watchEvent(eventName) {
+    opt.events.forEach(function watchEvent(eventName) {
       watcher.on(eventName, fn);
-    }
-
-    opt.events.forEach(watchEvent);
+    });
   }
 
   return watcher;

--- a/index.js
+++ b/index.js
@@ -23,6 +23,14 @@ function watch(glob, options, cb) {
 
   var opt = assignWith({}, defaults, options, assignNullish);
 
+  if (!opt.events) {
+    opt.events = ['add', 'change', 'unlink'];
+  }
+
+  if (!(opt.events instanceof Array)) {
+    opt.events = [opt.events];
+  }
+
   var queued = false;
   var running = false;
 
@@ -57,15 +65,11 @@ function watch(glob, options, cb) {
   if (typeof cb === 'function') {
     var fn = debounce(onChange, opt.delay, opt);
 
-    if (!opt.events) {
-      opt.events = ['add', 'change', 'unlink'];
+    function watchEvent(eventName) {
+      watcher.on(eventName, fn);
     }
 
-    opt.events.forEach(
-      function(eventName) {
-        watcher.on(eventName, fn);
-      }
-    );
+    opt.events.forEach(watchEvent);
   }
 
   return watcher;


### PR DESCRIPTION
In my current project, I need to `gulp.watch` for relatively rare `add` and `unlink` events, but `change` events are quite frequent and produce excessive load. Therefore this change would make my use case feasible without resorting to `gulp-watch`, which does offer this option. And I do think this is an appropriate addition. What do you think?