### PR TITLE
New: Add `emitErrors` option to disable emitted errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ var defaultOpts = {
   events: ['add', 'change', 'unlink'],
   ignoreInitial: true,
   queue: true,
+  // TODO: This default should change in a semver major
+  emitErrors: true,
 };
 
 function watch(glob, options, cb) {
@@ -32,7 +34,7 @@ function watch(glob, options, cb) {
   function runComplete(err) {
     running = false;
 
-    if (err) {
+    if (err && opt.emitErrors) {
       watcher.emit('error', err);
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -175,6 +175,22 @@ describe('glob-watcher', function() {
     watcher.on('ready', changeFile);
   });
 
+  it('allows the user to disable emitted errors', function(done) {
+    var expectedError = new Error('boom');
+
+    watcher = watch(outGlob, { emitErrors: false }, function(cb) {
+      cb(expectedError);
+      setTimeout(done, timeout * 3);
+    });
+
+    watcher.on('error', function(err) {
+      expect(err).toNotExist();
+    });
+
+    // We default `ignoreInitial` to true, so always wait for `on('ready')`
+    watcher.on('ready', changeFile);
+  });
+
   it('allows the user to disable queueing', function(done) {
     var runs = 0;
 


### PR DESCRIPTION
@contra @erikkemperman @th0r

It seems that the issue described in https://github.com/gulpjs/gulp/issues/2111 is due to this emitting an error on the watcher - which crashes the process if there are no handlers attached.

I made this an option so it can be a semver-minor version release but it almost seems like this was an oversight and should be handled somewhere as a bug.  That being said, someone/somewhere is probably relying on the crash behavior which means we would break them.  Thoughts?