### PR TITLE
Fix: Only emit `error` events when there is a listener (fixes #35)

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,18 @@ var defaultOpts = {
   queue: true,
 };
 
+function listenerCount(ee, evtName) {
+  if (typeof ee.listenerCount === 'function') {
+    return ee.listenerCount(evtName);
+  }
+
+  return ee.listeners(evtName).length;
+}
+
+function hasErrorListener(ee) {
+  return listenerCount(ee, 'error') !== 0;
+}
+
 function watch(glob, options, cb) {
   if (typeof options === 'function') {
     cb = options;
@@ -32,7 +44,7 @@ function watch(glob, options, cb) {
   function runComplete(err) {
     running = false;
 
-    if (err) {
+    if (err && hasErrorListener(watcher)) {
       watcher.emit('error', err);
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -159,7 +159,7 @@ describe('glob-watcher', function() {
     });
   });
 
-  it('emits an error if one occurs in the callback', function(done) {
+  it('emits an error if one occurs in the callback and handler attached', function(done) {
     var expectedError = new Error('boom');
 
     watcher = watch(outGlob, function(cb) {
@@ -169,6 +169,18 @@ describe('glob-watcher', function() {
     watcher.on('error', function(err) {
       expect(err).toEqual(expectedError);
       done();
+    });
+
+    // We default `ignoreInitial` to true, so always wait for `on('ready')`
+    watcher.on('ready', changeFile);
+  });
+
+  it('does not emit an error (and crash) when no handlers attached', function(done) {
+    var expectedError = new Error('boom');
+
+    watcher = watch(outGlob, function(cb) {
+      cb(expectedError);
+      setTimeout(done, timeout * 3);
     });
 
     // We default `ignoreInitial` to true, so always wait for `on('ready')`


### PR DESCRIPTION
cc @contra @erikkemperman @th0r @stevelacy @gauntface 

Based on the feedback in the other PR (#34), do you all agree that this is actually a bug and should be fixed in the way presented in this PR?  I also described it in #35 but will quote that here:

> It seems that this is a bug and it isn't likely that someone would rely on the "crashing" behavior (plus, it was never spec'ed by the tests). However, someone might want to attach an error listener and do something with the errors (outside of the gulp task system), so we should keep emitting errors. We can guard against the crash behavior by looking up if there's any handlers for 'error' and only emitting if any exist.