### PR TITLE
Upgrade: update chokidar and anymatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "coveralls": "npm run cover && istanbul-coveralls"
   },
   "dependencies": {
-    "anymatch": "^2.0.0",
+    "anymatch": "^3.0.1",
     "async-done": "^1.2.0",
-    "chokidar": "^2.0.0",
+    "chokidar": "^3.0.0",
     "is-negated-glob": "^1.0.0",
     "just-debounce": "^1.0.0",
     "object.defaults": "^1.1.0"


### PR DESCRIPTION
There are bugfixes in the new `chokidar` version (as well as speed improvements) that I needed.
I also updated `anymatch` since there is a new major version for it too while I was at it.

The new major version of `anymatch` does not allow for empty patterns (`null` or `undefined`) anymore so I refactored the code around this.

I also came up with small optimizations as well doing this (like not calling `anymatch` on positives when we do not need its result in `shouldBeIgnored`).