### PR TITLE
Upgrade: Update chkidar to version 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "anymatch": "^2.0.0",
     "async-done": "^1.2.0",
-    "chokidar": "^2.0.0",
+    "chokidar": "^3.0.2",
     "is-negated-glob": "^1.0.0",
     "just-debounce": "^1.0.0",
     "object.defaults": "^1.1.0"


### PR DESCRIPTION
Update chokidar version to reduce total installation size. Chokidar was rewritten to reduce its' size and increase performance. In a short word it has reduce installation size from 8.3 Mb to 496 Kb and reduce required files from around 1.25K to 26. Detailed explanation in the [blog](https://paulmillr.com/posts/chokidar-3-save-32tb-of-traffic/).