### PR TITLE
bump chokidar!

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "anymatch": "^2.0.0",
     "async-done": "^1.2.0",
-    "chokidar": "^2.0.0",
+    "chokidar": "^3.2.1",
     "is-negated-glob": "^1.0.0",
     "just-debounce": "^1.0.0",
     "object.defaults": "^1.1.0"


### PR DESCRIPTION
This needs to be done soo badly!
```
warning gulp > glob-watcher > chokidar > fsevents@1.2.9: 
One of your dependencies needs to upgrade to fsevents v2:
1) Proper nodejs v10+ support
```