### PR TITLE
Disable fsevents by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ var defaultOpts = {
   ignored: [],
   ignoreInitial: true,
   queue: true,
+  useFsEvents: false,
 };
 
 function listenerCount(ee, evtName) {


### PR DESCRIPTION
Since it would be a Semver-Major change to update chokidar this seems
like the next best thing. This explicitly opts-out of using fsevents
when instantiating chokidar as a default option. Folks could still
manually change this behavior if they wished. While this is a behavior
change it should only make things "slower" not "less reliable" and
would avoid the breakages we are seeing on 12 / 14 which appear to be
caused by .stop() being called on the watcher when nothing is being
watched, which might be a race condition in the tests.