### PR TITLE
Adding node_modules to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+/node_modules


### PR DESCRIPTION
At the moment this packages push to npm your local node_modules folder......which is a wrong behaviour because when installing it from a user perspective this package read everything from your node_modules....and we don't have the possibility to override some packages versions due to (fsevents bugs, chokidar etc)