### PR TITLE
Update of chokidar dep to 3.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "anymatch": "^2.0.0",
     "async-done": "^1.2.0",
-    "chokidar": "^2.0.0",
+    "chokidar": "^3.5.2",
     "is-negated-glob": "^1.0.0",
     "just-debounce": "^1.0.0",
     "normalize-path": "^3.0.0",


### PR DESCRIPTION
This update goal to fix a security vulnerability which come with an older version of chokidar.

Before chokidar@3.5.2, this package have an older version of glob-parent (< v5.1.2) which have "Regular expression denial of service".

v5.1.2 of glob-parent fix this vulnerability.