### PR TITLE
npm audit fix - Upgrade chokidar to v3.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "anymatch": "^2.0.0",
     "async-done": "^1.2.0",
-    "chokidar": "^2.0.0",
+    "chokidar": "^3.5.2",
     "is-negated-glob": "^1.0.0",
     "just-debounce": "^1.0.0",
     "normalize-path": "^3.0.0",


### PR DESCRIPTION
Include fix for "Regular expression denial of service"  in "glob-parent" v5.1.2